### PR TITLE
Reduce memory consumption by cleaning up un-needed array

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -147,6 +147,7 @@ module.exports = NodeHelper.create({
     console.log("[GPHOTO] Scan finished :", this.tempItems.length)
     //this.sendSocketNotification("IMAGE_LIST", this.items)
     this.items = this.tempItems
+    this.tempItems= [];
     if (this.started == false) {
       this.started = true
       this.broadcast()


### PR DESCRIPTION
The tempItems array doesn't get cleared until the start of each scan, this memory is un-neccessary held open so we should release it as early as possible.