### PR TITLE
Adding opacity controls for readability.

### DIFF
--- a/MMM-GooglePhotos.js
+++ b/MMM-GooglePhotos.js
@@ -11,6 +11,7 @@ Module.register("MMM-GooglePhotos", {
     showHeight: "600px",
     originalWidthPx: 800, // original size of loaded image. (related with image quality)
     originalHeightPx: 600,
+    opacity: 1, // resulting image opacity. Consider reducing this value if you are using this module as a background picture frame
     mode: "cover", // "cover" or "contain" (https://www.w3schools.com/cssref/css3_pr_background-size.asp)
   },
 
@@ -40,7 +41,7 @@ Module.register("MMM-GooglePhotos", {
     setTimeout(()=>{
       image.style.backgroundImage = "unset"
       image.style.backgroundImage = "url('" + url + "')"
-      image.style.opacity = 1
+      image.style.opacity = this.config.opacity;
       if (this.config.mode == "hybrid") {
         var rect = image.getBoundingClientRect()
         var rr = ((rect.width / rect.height) > 1) ? "h" : "v"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ travel to paris : AGj1epU5VMNoBGK9GDX3k_zDQaPT16Fe56o0N93eN6aXn-f21M98
     showHeight: "600px",
     originalWidthPx: 800, // original size of loaded image. (related with image quality)
     originalHeightPx: 600, // Bigger size gives you better quality, but can give you network burden.
+    opacity: 1, // target "opacity" property (https://www.w3schools.com/cssref/css3_pr_opacity.asp)
     mode: "hybrid", // "cover" or "contain" (https://www.w3schools.com/cssref/css3_pr_background-size.asp)
     //ADDED. "hybrid" : if you set as "hybrid" it will change "cover" and "contain" automatically by aspect ratio.
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "google-auth-library": "^1.6.1",
-    "grpc": "^1.13.0",
     "open": "^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Really basic opacity controls. I found that reducing this value makes some foreground modules more readable if the purpose of this module was to be a background photo frame on smaller screens.

Another idea would be to make this value more dynamic via the notification system, but that's outside the scope of this change, which is to simply make the value externally configurable.